### PR TITLE
Add dataset statistics script

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ If you use this code base in your research, please cite our paper with the follo
   year={2024}
 }
 ```
+## Dataset Statistics
+
+Run `dataset_stats.py` to show basic information about a dataset file.
+
+```bash
+python dataset_stats.py data/prosqa_train.json
+```
+
 
 ## Heart Demo
 

--- a/dataset_stats.py
+++ b/dataset_stats.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+import argparse
+import json
+from statistics import mean
+from typing import List
+
+
+def compute_stats(data: List[dict]) -> dict:
+    num_samples = len(data)
+    step_counts = [len(d.get("steps", [])) for d in data]
+    avg_steps = mean(step_counts) if step_counts else 0
+    question_lengths = [len(d.get("question", "").split()) for d in data]
+    avg_question_len = mean(question_lengths) if question_lengths else 0
+
+    step_word_lengths = []
+    for d in data:
+        for step in d.get("steps", []):
+            step_word_lengths.append(len(step.split()))
+    avg_step_len = mean(step_word_lengths) if step_word_lengths else 0
+
+    return {
+        "num_samples": num_samples,
+        "avg_steps": avg_steps,
+        "avg_question_length": avg_question_len,
+        "avg_step_length": avg_step_len,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show basic statistics for a dataset JSON file")
+    parser.add_argument("path", help="Path to dataset JSON file")
+    args = parser.parse_args()
+
+    data = json.load(open(args.path))
+    stats = compute_stats(data)
+
+    print(f"Samples: {stats['num_samples']}")
+    print(f"Average steps per sample: {stats['avg_steps']:.2f}")
+    print(f"Average question length (words): {stats['avg_question_length']:.2f}")
+    print(f"Average step length (words): {stats['avg_step_length']:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add utility to compute statistics for dataset json files
- document dataset_stats.py usage in README

## Testing
- `python dataset_stats.py data/prosqa_train.json`

------
https://chatgpt.com/codex/tasks/task_e_68709b5686888327b6335e3825a1eaa2